### PR TITLE
add map type conversion

### DIFF
--- a/avro_to_bigquery/converter.py
+++ b/avro_to_bigquery/converter.py
@@ -98,15 +98,16 @@ def _convert_complex_type(avro_type):
         key_field = {
             "name": "key",
             "type": "string",
-            "doc": "Key for map avro field"
+            "doc": "Key for map avro field",
         }
         value_field = {
             "name": "value",
             "type": avro_type["values"],
-            "doc": "Value for map avro field"
+            "doc": "Value for map avro field",
         }
-        fields = tuple(map(lambda f: _convert_field(f),
-                       [key_field, value_field]))
+        fields = tuple(
+            map(lambda f: _convert_field(f), [key_field, value_field])
+        )
     elif "logicalType" in avro_type:
         field_type = AVRO_TO_BIGQUERY_TYPES[avro_type["logicalType"]]
     else:

--- a/avro_to_bigquery/converter.py
+++ b/avro_to_bigquery/converter.py
@@ -91,6 +91,22 @@ def _convert_complex_type(avro_type):
             field_type = AVRO_TO_BIGQUERY_TYPES[avro_type["items"]]
     elif avro_type["type"] == "enum":
         field_type = AVRO_TO_BIGQUERY_TYPES[avro_type["type"]]
+    elif avro_type["type"] == "map":
+        field_type = "RECORD"
+        mode = "REPEATED"
+        # Create artificial fields to represent map in BQ
+        key_field = {
+            "name": "key",
+            "type": "string",
+            "doc": "Key for map avro field"
+        }
+        value_field = {
+            "name": "value",
+            "type": avro_type["values"],
+            "doc": "Value for map avro field"
+        }
+        fields = tuple(map(lambda f: _convert_field(f),
+                       [key_field, value_field]))
     elif "logicalType" in avro_type:
         field_type = AVRO_TO_BIGQUERY_TYPES[avro_type["logicalType"]]
     else:

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -100,19 +100,13 @@ def test_convert_avro_schema_to_bigquery_schema():
                     },
                 ],
             },
-            {
-                "name": "map_field",
-                "type": {"type": "map", "values": "int"}
-            },
+            {"name": "map_field", "type": {"type": "map", "values": "int"}},
             {
                 "name": "complex_map",
                 "type": {
                     "type": "map",
-                    "values": {
-                        "type": "array",
-                        "items": "int"
-                    }
-                }
+                    "values": {"type": "array", "items": "int"},
+                },
             },
         ],
     }

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -100,6 +100,20 @@ def test_convert_avro_schema_to_bigquery_schema():
                     },
                 ],
             },
+            {
+                "name": "map_field",
+                "type": {"type": "map", "values": "int"}
+            },
+            {
+                "name": "complex_map",
+                "type": {
+                    "type": "map",
+                    "values": {
+                        "type": "array",
+                        "items": "int"
+                    }
+                }
+            },
         ],
     }
 
@@ -107,7 +121,7 @@ def test_convert_avro_schema_to_bigquery_schema():
     s = convert_schema(avs)
 
     # assert
-    assert len(s) == 15
+    assert len(s) == 17
     assert s[0].name == "full_name"
     assert s[1].field_type == "INTEGER"
     assert s[2].description == "Just a boolean tester"
@@ -132,6 +146,16 @@ def test_convert_avro_schema_to_bigquery_schema():
     assert s[13].field_type == "DATE"
     assert s[13].mode == "REPEATED"
     assert s[14].field_type == "STRING"
+    assert s[15].name == "map_field"
+    assert s[15].field_type == "RECORD"
+    assert s[15].mode == "REPEATED"
+    assert s[15].fields[0].field_type == "STRING"
+    assert s[15].fields[1].field_type == "INTEGER"
+    assert s[15].fields[0].name == "key"
+    assert s[15].fields[1].name == "value"
+    assert s[16].fields[0].field_type == "STRING"
+    assert s[16].fields[1].field_type == "INTEGER"
+    assert s[16].fields[1].mode == "REPEATED"
 
 
 def test_incorrect_nullable_field():


### PR DESCRIPTION
## Description

Adding support for the complex type `map`. The `map` type is documented [here](https://avro.apache.org/docs/current/spec.html#Maps), the conversion standard to BigQuery type is documented [here](https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-avro#:~:text=types%20are%20ignored.-,map%3CT%3E,-RECORD).

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [x] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/avro-to-bigquery/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
